### PR TITLE
Added igloo_task_size to change user process stack/mmap_base from kernel commandline

### DIFF
--- a/arch/arm/mm/mmap.c
+++ b/arch/arm/mm/mmap.c
@@ -38,8 +38,13 @@ static unsigned long mmap_base(unsigned long rnd)
 		gap = MIN_GAP;
 	else if (gap > MAX_GAP)
 		gap = MAX_GAP;
-
-	return PAGE_ALIGN(TASK_SIZE - gap - rnd);
+    //Begin for igloo: if we moved the stack, we have to move mmap
+    if(igloo_task_size) {
+        return PAGE_ALIGN(igloo_task_size - gap - rnd);
+    } else {
+        return PAGE_ALIGN(TASK_SIZE - gap - rnd);
+    }
+    //End for igloo
 }
 
 /*

--- a/arch/mips/mm/mmap.c
+++ b/arch/mips/mm/mmap.c
@@ -42,7 +42,13 @@ static unsigned long mmap_base(unsigned long rnd)
 	else if (gap > MAX_GAP)
 		gap = MAX_GAP;
 
-	return PAGE_ALIGN(TASK_SIZE - gap - rnd);
+    //Begin for igloo: if we moved the stack, we have to move mmap
+    if(igloo_task_size) {
+        return PAGE_ALIGN(igloo_task_size - gap - rnd);
+    } else {
+        return PAGE_ALIGN(TASK_SIZE - gap - rnd);
+    }
+    //End for igloo
 }
 
 #define COLOUR_ALIGN(addr, pgoff)				\

--- a/arch/x86/mm/mmap.c
+++ b/arch/x86/mm/mmap.c
@@ -90,7 +90,13 @@ static unsigned long mmap_base(unsigned long rnd)
 	else if (gap > MAX_GAP)
 		gap = MAX_GAP;
 
-	return PAGE_ALIGN(TASK_SIZE - gap - rnd);
+    //Begin for igloo: if we moved the stack, we have to move mmap
+    if(igloo_task_size) {
+        return PAGE_ALIGN(igloo_task_size - gap - rnd);
+    } else {
+        return PAGE_ALIGN(TASK_SIZE - gap - rnd);
+    }
+    //End for igloo
 }
 
 /*

--- a/fs/binfmt_elf.c
+++ b/fs/binfmt_elf.c
@@ -857,8 +857,15 @@ static int load_elf_binary(struct linux_binprm *bprm)
 
 	/* Do this so that we can load the interpreter, if need be.  We will
 	   change some of these later */
-	retval = setup_arg_pages(bprm, randomize_stack_top(STACK_TOP),
-				 executable_stack);
+    //Begin for igloo: if we moved the stack, we have to move mmap
+    if(igloo_task_size) {
+        retval = setup_arg_pages(bprm, randomize_stack_top(igloo_task_size),
+                     executable_stack);
+    } else {
+        retval = setup_arg_pages(bprm, randomize_stack_top(STACK_TOP),
+                     executable_stack);
+    }
+    //End for igloo
 	if (retval < 0)
 		goto out_free_dentry;
 	

--- a/fs/exec.c
+++ b/fs/exec.c
@@ -668,7 +668,7 @@ int setup_arg_pages(struct linux_binprm *bprm,
 	unsigned long stack_size;
 	unsigned long stack_expand;
 	unsigned long rlim_stack;
-
+    
 #ifdef CONFIG_STACK_GROWSUP
 	/* Limit stack size */
 	stack_base = rlimit_max(RLIMIT_STACK);
@@ -1323,6 +1323,10 @@ void setup_new_exec(struct linux_binprm * bprm)
 	 * some architectures like powerpc
 	 */
 	current->mm->task_size = TASK_SIZE;
+    //Begin for igloo: if we moved the stack, we have to move mmap
+    if(igloo_task_size)
+        current->mm->task_size = igloo_task_size;
+    //End for igloo
 
 	/* install the new credentials */
 	if (!uid_eq(bprm->cred->uid, current_euid()) ||

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -24,6 +24,23 @@
 #include <linux/err.h>
 #include <linux/page_ref.h>
 
+//Begin for igloo: we can relocate user stack and mmap_base to compensate for 
+//                 the original kernel's kernel base being different
+#include <linux/moduleparam.h>
+static unsigned long igloo_task_size = 0;
+static int __init early_igloo_task_size(char *p) {
+    unsigned long task_size;
+    if(kstrtoul(p, 0, &task_size) < 0 ) {
+        pr_warn("Could not parse igloo_task_size parameter %s\n", p);
+        return -1;
+    }
+    igloo_task_size = task_size;
+    pr_warn("Using igloo_task_size: 0x%lx\n", igloo_task_size);
+    return 0;
+}
+early_param("igloo_task_size", early_igloo_task_size);
+//End for igloo
+
 struct mempolicy;
 struct anon_vma;
 struct anon_vma_chain;


### PR DESCRIPTION
Allows us to specify `igloo_task_size` to the kernel to fake out some effects of having a different `CONFIG_PAGE_OFFSET`/`CONFIG_VMSPLIT` setting than used at compile time.